### PR TITLE
Update WordList.yml

### DIFF
--- a/styles/Splunk/WordList.yml
+++ b/styles/Splunk/WordList.yml
@@ -15,11 +15,13 @@ swap:
   '(?:addon|add-On|Add-On|AddOn)': add-on|Add-on
   '(?:addons|add-Ons|Add-Ons|AddOns)': add-ons|Add-ons
   'above': higher for software versions
+  'abort': force quit, cancel, fail, close, stop, or end (unless referring to a specific command or system language)
   'allows you to': lets you
   'at present': now
   'basic steps': steps
   'be sure to': make sure
   'boolean': Boolean
+  'bulletproof': safe, secure, solid, or impenetrable 
   'can not': can't|cannot
   'carriage return': line break
   'check out': see
@@ -42,11 +44,13 @@ swap:
   'end point': endpoint
   'epoch time': UNIX time
   'execute': run
+  'fatal': unrecoverable
   'fetch': retrieve
   '(?:field\/value pair|field value pair)': field-value pair
   'filename': file name
   'filesystem': file system
   'for instance': for example
+  'hangs': stops responding or freezes
   'hard code': hard-code
   'hard coded': hard-coded
   'hard coding': hard-coding
@@ -55,10 +59,12 @@ swap:
   'have plans': plan
   'have the option to': can
   'hex': hexadecimal
+  'hit': select or enter
   'homepage': home page
   'hostname': host name
   'Internet': internet
   'is able to': can
+  'kill': quit, stop, or end (unless referring to *nix command or process)
   '(?:key\/value pair|key value pair)': key-value pair
   'later': higher for software versions
   'launch': open
@@ -106,6 +112,7 @@ swap:
   '(?:SplunkWeb|Splunk UI|Splunk Web UI|Web UI|Web Interface)': Splunk Web
   'Spunk': Splunk
   '(?:stand-alone|stand alone)': standalone
+  'suicide mode': time until restart
   'toggle': switch
   'takes you to': opens
   'TA': add-on


### PR DESCRIPTION
Moved `hangs`, `hit`, and `suicide mode` from Inclusivity.yml to here. Also added `abort`, `bulletproof`, `fatal`, and `kill`.