### PR TITLE
Added entry to catch 'conf file' and 'CONF file'

### DIFF
--- a/styles/Splunk/WordList.yml
+++ b/styles/Splunk/WordList.yml
@@ -28,6 +28,8 @@ swap:
   'check out': see
   'checkbox': check box
   'cog': gear|gear icon
+  'conf file": .conf file
+  'CONF file": .conf file
   'consult': see
   'could': can
   'DA': add-on


### PR DESCRIPTION
Needs to be .conf file.

Fabri -- Can you check whether 'conf file' and "CONF file" capitalizations are caught in this rule?