### PR TITLE
Update Numbers.yml

### DIFF
--- a/styles/Splunk/Numbers.yml
+++ b/styles/Splunk/Numbers.yml
@@ -5,8 +5,7 @@ nonword: true
 ignorecase: true
 level: warning
 scope: sentence
-tokens:
-  - '\s\d\s(?!hours|seconds|days|weeks|months|years|minutes)'
+tokens:)'
   - '3rd-party'
   - '3rd party'
   - '^\d\s'


### PR DESCRIPTION
We don't want to flag numbers, especially when they are in reference to time, days, minutes, hours, etc. (Our new guidance actually says to use numbers in most every place, but the guidance for using numbers with time has always stood.)