### PR TITLE
Update WordList.yml

### DIFF
--- a/styles/Splunk/DontUse.yml
+++ b/styles/Splunk/DontUse.yml
@@ -4,7 +4,6 @@ link: https://docs.splunk.com/Documentation/StyleGuide/current/StyleGuide/Usaged
 ignorecase: true
 level: error
 tokens:
-  - '(?:the|The) (?:Splunk IT Cloud|Splunk Security Cloud|Splunk Observability Cloud)'
   - a.k.a.
   - aka
   - and/or

--- a/styles/Splunk/ProductTerms.yml
+++ b/styles/Splunk/ProductTerms.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Verify your use of '%s' with the Splunk product terminology guidelines. Use a definite article only if the product acts as an adjective."
+link: 'https://docs.splunk.com/Documentation/StyleGuide/current/StyleGuide/Terminology'
+level: warning
+ignorecase: true
+tokens:
+  - '(?:the|The) (?:Splunk IT Cloud|Splunk Security Cloud|Splunk Observability Cloud)'

--- a/styles/Splunk/WordList.yml
+++ b/styles/Splunk/WordList.yml
@@ -11,6 +11,7 @@ swap:
   'SIT': Splunk IT Cloud
   'SSC': Splunk Security Cloud
   'SOC': Splunk Observability Cloud
+  'Splunk Observability Cloud platform': Splunk Observability Cloud
   '(?:UNIX|Linux)': Use *nix if both Linux and UNIX are supported. 
   '(?:addon|add-On|Add-On|AddOn)': add-on|Add-on
   '(?:addons|add-Ons|Add-Ons|AddOns)': add-ons|Add-ons


### PR DESCRIPTION
Added Splunk Observability Cloud platform to WordList, removed the rule catching product terms with definite articles from DontUse and transferred them to a new file called ProductTerms.