### PR TITLE
Update LoginVerb.yml

### DIFF
--- a/styles/Splunk/LoginVerb.yml
+++ b/styles/Splunk/LoginVerb.yml
@@ -1,6 +1,7 @@
 extends: sequence
 message: "Use log in as a verb. Don't use log on."
 ignorecase: true
+level: suggestion
 tokens:
   - tag: VB|VBD|VBG|VBN|VBP|VBZ
     pattern: '(?:log into|log in|login|log on)'


### PR DESCRIPTION
Adding a MinAlertLevel warning to test whether excluding this extension breaks the flag. (Right now, without the level included, Vale doesn't flag the error for me.)