### PR TITLE
Update WordList.yml

### DIFF
--- a/styles/Splunk/WordList.yml
+++ b/styles/Splunk/WordList.yml
@@ -113,7 +113,7 @@ swap:
   '(?:Splunk dev portal|Splunk Dev Portal)': Splunk Developer Portal
   'Splunk Enterprise platform': Splunk Enterprise
   '(?:Splunk Software|Splunk Software instance)': Splunk software
-  '(?:SplunkWeb|Splunk UI|Splunk Web UI|Web UI|Web Interface)': Splunk Web
+  '(?:SplunkWeb|a Splunk UI|the Splunk UI|Splunk Web UI|Web UI|Web Interface)': Splunk Web
   'Spunk': Splunk
   '(?:stand-alone|stand alone)': standalone
   'suicide mode': time until restart


### PR DESCRIPTION
Because we have a product called "Splunk UI", I updated the Splunk Web entry to catch "a Splunk UI" or "the Splunk UI" so it won't erroneously flag the product.