### PR TITLE
Update Ampersand.yml

### DIFF
--- a/styles/Splunk/Ampersand.yml
+++ b/styles/Splunk/Ampersand.yml
@@ -1,10 +1,10 @@
 extends: existence
-message: "Don't use an ampersand in place of the word 'and'. Always write out 'and' unless the ampersand is part of a proper name."
+message: "Write out 'and' unless the ampersand is part of a proper name."
 link: https://docs.splunk.com/Documentation/StyleGuide/current/StyleGuide/Ampersand
 nonword: true
-level: error
+level: warning
 ignorecase: false
 scope: sentence
 tokens:
-  - '[a-zA-Z] \& [a-zA-Z]+'
+  - "&"
 


### PR DESCRIPTION
Updated token from `[a-zA-Z] \& [a-zA-Z]+` to "&" because VSCode and Ponydocs were not capturing ampersands in any usage. Also updated level from error to warning.