### PR TITLE
Update and rename Inclusivity.yml to InclusiveLanguage.yml

### DIFF
--- a/styles/Splunk/InclusiveLanguage.yml
+++ b/styles/Splunk/InclusiveLanguage.yml
@@ -1,29 +1,20 @@
 extends: substitution
-message: "Avoid biased language. Use '%s' instead of '%s'."
+message: "Strie for inclusive language. Use '%s' instead of '%s'."
 link: 'https://docs.splunk.com/Documentation/StyleGuide/current/StyleGuide/Inclusivity'
-level: error
+level: warning
 ignorecase: true
 action:
   name: replace
 swap:
   abnormal: atypical or not typical
-  blacklist: deny list, reject, deny, or exclude
   disable: deactivate, deselect, hide, inactive, turn off
   disabled: deactivated, deselected, hidden, turned off, unavailable
   disables: deactivates, deselects, hides, turns off, makes unavailable
   dummy data: placeholder data
-  enable: Don't use as the counteraction of turning off a feature. Use activate, select, show, turn on, or the like.
-  enabled: Don't use as the counteraction of turning off a feature. Use activated, selected, turned on, or the like.
-  enables: Don't use as the counteraction of turning off a feature. Use activated, selected, turned on, or the like.
   execute: run 
   flesh-colored: dark brown, cream, or beige
   skin-toned: dark brown, cream, or beige
   first-class: top-level
-  grandfathered: exempt
   illegal characters: invalid characters
   mankind: all, everyone, humanity, or humankind
-  master: manager, primary, or main
-  master branch: main branch
   sanity check: review
-  slave: peer or replica
-  whitelist: allow list, allow, accept, or include


### PR DESCRIPTION
Removed the 4 major biased language so we can flag these inclusive language considerations as warnings instead of errors.