### PR TITLE
Update SplunkProducts.yml

### DIFF
--- a/styles/Splunk/SplunkProducts.yml
+++ b/styles/Splunk/SplunkProducts.yml
@@ -6,7 +6,7 @@ ignorecase: false
 action:
   name: replace
 swap:
-  'Observability Cloud': Splunk Observability Cloud
+  '(?<!Splunk\s)Observability Cloud(?! Cloud)': Splunk Observability Cloud
   '^Splunk platform': The Splunk platform
   'SIT': Splunk IT Cloud
   'SSC': Splunk Security Cloud


### PR DESCRIPTION
Added negative lookbehind and lookahead assertions so Observability Cloud gets flagged only when its used on its own, not when it's written correctly.