### PR TITLE
Create LatinEtc.yml

### DIFF
--- a/styles/Splunk/LatinEtc.yml
+++ b/styles/Splunk/LatinEtc.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: "Don't use Latin abbreviations or terms. Be specific and concrete when you write."
+link: 'https://docs.splunk.com/Documentation/StyleGuide/current/StyleGuide/USspelling'
+level: warning
+ignorecase: false
+scope: sentence
+tokens:
+  - 'etc'
+  - 'etc.'


### PR DESCRIPTION
Created file because there isn't a 1:1 substitution like there are other Latin abbreviations. This one flags for the existence rather than the swap.